### PR TITLE
Fix #28: bad handing of bufflen and asyncBuff (origin of CubicSDR slowdown)

### DIFF
--- a/Streaming.cpp
+++ b/Streaming.cpp
@@ -132,8 +132,9 @@ void SoapyRTLSDR::rx_callback(unsigned char *buf, uint32_t len)
     //increment buffers available under lock
     //to avoid race in acquireReadBuffer wait
     {
-        std::lock_guard<std::mutex> lock(_buf_mutex);
-        _buf_count++;
+    std::lock_guard<std::mutex> lock(_buf_mutex);
+    _buf_count++;
+
     }
 
     //notify readStream()
@@ -220,11 +221,11 @@ SoapySDR::Stream *SoapyRTLSDR::setupStream(
     }
 
     bufferLength = DEFAULT_BUFFER_LENGTH;
-    if (args.count("buflen") != 0)
+    if (args.count("bufflen") != 0)
     {
         try
         {
-            int bufferLength_in = std::stoi(args.at("buflen"));
+            int bufferLength_in = std::stoi(args.at("bufflen"));
             if (bufferLength_in > 0)
             {
                 bufferLength = bufferLength_in;
@@ -257,12 +258,11 @@ SoapySDR::Stream *SoapyRTLSDR::setupStream(
             int asyncBuffs_in = std::stoi(args.at("asyncBuffs"));
             if (asyncBuffs_in > 0)
             {
-                asyncBuffs = asyncBuffs;
+                asyncBuffs = asyncBuffs_in;
             }
         }
         catch (const std::invalid_argument &){}
     }
-
     if (tunerType == RTLSDR_TUNER_E4000) {
         IFGain[0] = 6;
         IFGain[1] = 9;


### PR DESCRIPTION
@guruofquality @cjcliffe Greetings ! 
I've found the definitive cause of #28, and it is entirely SoapyRTLSDR fault :)
This PR fixes 2 things:
-  asyncBuffs parameter is not read and saved (self-assignment bug)
-  bufflen inconsistent handling due to a typo, resulting that   ``bufflen = DEFAULT_BUFFER_LENGTH =  (16 * 32 * 512) = 262144`` no matter what CubicSDR requested.

Now the source of slowdown in CubicSDR is that ``bufflen`` was used indirectly through a ``getStreamMTU()`` call, which finally dimension array-like incoming buffers handled with ``memcpy``, ``memove`` and such.

So after fixing the bufflen handing, I experimented on my machine (Core i7-2630QM Sandy-Bridge laptop, was high-end in 2011) 
- ``bufflen = 16384``, so MTU of 8192 as was the setting in SoapyRTLSDR v0.22 shows CubicSDR fast as before,
- ``16384 <  bufflen < 65536`` : no apparent slowdown,
-  ``bufflen  = 131072 or 262144`` (new default) : CubicSDR slows down dramatically.

On one side maybe CubicSDR should be smarter in buffer handling instead of relying on CPU cache, and ``memove, memcpy`` but on the other side now  ``bufflen`` will have to be set carefully depending on the current machine because of its much higher value.