### PR TITLE
do not reset buffer on tune

### DIFF
--- a/Settings.cpp
+++ b/Settings.cpp
@@ -377,7 +377,6 @@ void SoapyRTLSDR::setFrequency(
     if (name == "RF")
     {
         centerFrequency = (uint32_t) frequency;
-        resetBuffer = true;
         SoapySDR_logf(SOAPY_SDR_DEBUG, "Setting center freq: %d", centerFrequency);
         rtlsdr_set_center_freq(dev, centerFrequency);
     }


### PR DESCRIPTION
if desired, the user may do this by deactivating/reactivating the stream (which also triggers a reset and corresponding buffer drain).

This seems a little controversial to me as it could break existing code slightly.