### PR TITLE
Stop advertising full-duplex capabilities

### DIFF
--- a/Settings.cpp
+++ b/Settings.cpp
@@ -187,6 +187,11 @@ size_t SoapyRTLSDR::getNumChannels(const int dir) const
     return (dir == SOAPY_SDR_RX) ? 1 : 0;
 }
 
+bool SoapyRTLSDR::getFullDuplex(const int direction, const size_t channel) const
+{
+	return false;
+}
+
 /*******************************************************************
  * Antenna API
  ******************************************************************/

--- a/SoapyRTLSDR.hpp
+++ b/SoapyRTLSDR.hpp
@@ -66,6 +66,8 @@ public:
 
     size_t getNumChannels(const int) const;
 
+    bool getFullDuplex(const int direction, const size_t channel) const;
+
     /*******************************************************************
      * Stream API
      ******************************************************************/


### PR DESCRIPTION
SoapySDR currently advertises the RTL-SDR's RX channel as being full-duplex:
```
$ SoapySDRUtil --probe

...

----------------------------------------------------
-- Device identification
----------------------------------------------------
  driver=RTLSDR
  hardware=R820T

...

----------------------------------------------------
-- RX Channel 0
----------------------------------------------------
  Full-duplex: YES

...
```

This is obviously nonsense; I assume it only does this because SoapyRTLSDR doesn't override [the default](https://github.com/pothosware/SoapySDR/blob/66306d24e07d2cd67f292286f3f460734700c234/lib/Device.cpp#L56) (true, full-duplex).

This very simple PR makes SoapyRTLSDR override `getFullDuplex` to always return `false` (half-duplex, i.e. no only RX and no TX capabilities).