### PR TITLE
rtl - reimplement find and make by serial only

### DIFF
--- a/Settings.cpp
+++ b/Settings.cpp
@@ -44,7 +44,9 @@ SoapyRTLSDR::SoapyRTLSDR(const SoapySDR::Kwargs &args):
     digitalAGC(false),
     ticks(false),
     bufferedElems(0),
-    resetBuffer(false)
+    resetBuffer(false),
+    gainMin(0.0),
+    gainMax(0.0)
 {
     if (args.count("label") != 0) SoapySDR_logf(SOAPY_SDR_INFO, "Opening %s...", args.at("label").c_str());
 

--- a/SoapyRTLSDR.hpp
+++ b/SoapyRTLSDR.hpp
@@ -279,7 +279,5 @@ public:
     long long bufTicks;
     std::atomic<bool> resetBuffer;
 
-    static int rtl_count;
-    static std::vector<SoapySDR::Kwargs> rtl_devices;
-    static double gainMin, gainMax;
+    double gainMin, gainMax;
 };


### PR DESCRIPTION
* Removed open/filter by label, as its redundant with serial
* Removed rtl=indexno keyword, it clashed with installs of the gr-osmosdr rtl and open by serial is strongly preferred.
* Open device index is now reported in getHardwareInfo() under the index key
* Replaces static gain min/gain max with per open device calculated gains
* Removes static device cache, now only the tuner string is cached as its probably useful info during discovery
* Severely reduced complexity of find function and constructor
* Enumerating an open RTL in another process would report keyword available as Yes/No. This was removed, however the tuner will report unavailable