### PR TITLE
Biastee support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,15 @@ if (APPLE)
    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wc++11-extensions")
 endif(APPLE)
 
+# check if rtlsdr library includes support for bias-tee
+include(CheckFunctionExists)
+set(CMAKE_REQUIRED_LIBRARIES ${RTLSDR_LIBRARIES})
+check_function_exists(rtlsdr_set_bias_tee HAS_RTLSDR_SET_BIAS_TEE)
+unset(CMAKE_REQUIRED_LIBRARIES)
+if (HAS_RTLSDR_SET_BIAS_TEE)
+    add_definitions(-DHAS_RTLSDR_SET_BIAS_TEE)
+endif()
+
 set(OTHER_LIBS "" CACHE STRING "Other libraries")
 
 SOAPY_SDR_MODULE_UTIL(

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -542,7 +542,7 @@ SoapySDR::ArgInfoList SoapyRTLSDR::getSettingInfo(void) const
 
     SoapySDR::ArgInfo biasTeeArg;
 
-    biasTeeArg.key = "bias_tee";
+    biasTeeArg.key = "biastee";
     biasTeeArg.value = "false";
     biasTeeArg.name = "Bias Tee";
     biasTeeArg.description = "RTL-SDR Blog V.3 Bias-Tee Mode";
@@ -587,7 +587,7 @@ void SoapyRTLSDR::writeSetting(const std::string &key, const std::string &value)
         SoapySDR_logf(SOAPY_SDR_DEBUG, "RTL-SDR digital agc mode: %s", digitalAGC ? "true" : "false");
         rtlsdr_set_agc_mode(dev, digitalAGC ? 1 : 0);
     }
-    else if (key == "bias_tee")
+    else if (key == "biastee")
     {
         biasTee = (value == "true") ? true: false;
         SoapySDR_logf(SOAPY_SDR_DEBUG, "RTL-SDR bias tee mode: %s", biasTee ? "true" : "false");
@@ -605,7 +605,7 @@ std::string SoapyRTLSDR::readSetting(const std::string &key) const
         return offsetMode?"true":"false";
     } else if (key == "digital_agc") {
         return digitalAGC?"true":"false";
-    } else if (key == "bias_tee") {
+    } else if (key == "biastee") {
         return biasTee?"true":"false";
     }
 

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -42,7 +42,9 @@ SoapyRTLSDR::SoapyRTLSDR(const SoapySDR::Kwargs &args):
     gainMode(false),
     offsetMode(false),
     digitalAGC(false),
+#if HAS_RTLSDR_SET_BIAS_TEE
     biasTee(false),
+#endif
     ticks(false),
     bufferedElems(0),
     resetBuffer(false),
@@ -540,6 +542,7 @@ SoapySDR::ArgInfoList SoapyRTLSDR::getSettingInfo(void) const
 
     setArgs.push_back(digitalAGCArg);
 
+#if HAS_RTLSDR_SET_BIAS_TEE
     SoapySDR::ArgInfo biasTeeArg;
 
     biasTeeArg.key = "biastee";
@@ -549,6 +552,7 @@ SoapySDR::ArgInfoList SoapyRTLSDR::getSettingInfo(void) const
     biasTeeArg.type = SoapySDR::ArgInfo::BOOL;
 
     setArgs.push_back(biasTeeArg);
+#endif
 
     SoapySDR_logf(SOAPY_SDR_DEBUG, "SETARGS?");
 
@@ -587,12 +591,14 @@ void SoapyRTLSDR::writeSetting(const std::string &key, const std::string &value)
         SoapySDR_logf(SOAPY_SDR_DEBUG, "RTL-SDR digital agc mode: %s", digitalAGC ? "true" : "false");
         rtlsdr_set_agc_mode(dev, digitalAGC ? 1 : 0);
     }
+#if HAS_RTLSDR_SET_BIAS_TEE
     else if (key == "biastee")
     {
         biasTee = (value == "true") ? true: false;
         SoapySDR_logf(SOAPY_SDR_DEBUG, "RTL-SDR bias tee mode: %s", biasTee ? "true" : "false");
         rtlsdr_set_bias_tee(dev, biasTee ? 1 : 0);
     }
+#endif
 }
 
 std::string SoapyRTLSDR::readSetting(const std::string &key) const
@@ -605,8 +611,10 @@ std::string SoapyRTLSDR::readSetting(const std::string &key) const
         return offsetMode?"true":"false";
     } else if (key == "digital_agc") {
         return digitalAGC?"true":"false";
+#if HAS_RTLSDR_SET_BIAS_TEE
     } else if (key == "biastee") {
         return biasTee?"true":"false";
+#endif
     }
 
     SoapySDR_logf(SOAPY_SDR_WARNING, "Unknown setting '%s'", key.c_str());

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -42,6 +42,7 @@ SoapyRTLSDR::SoapyRTLSDR(const SoapySDR::Kwargs &args):
     gainMode(false),
     offsetMode(false),
     digitalAGC(false),
+    biasTee(false),
     ticks(false),
     bufferedElems(0),
     resetBuffer(false),
@@ -539,6 +540,16 @@ SoapySDR::ArgInfoList SoapyRTLSDR::getSettingInfo(void) const
 
     setArgs.push_back(digitalAGCArg);
 
+    SoapySDR::ArgInfo biasTeeArg;
+
+    biasTeeArg.key = "bias_tee";
+    biasTeeArg.value = "false";
+    biasTeeArg.name = "Bias Tee";
+    biasTeeArg.description = "RTL-SDR Blog V.3 Bias-Tee Mode";
+    biasTeeArg.type = SoapySDR::ArgInfo::BOOL;
+
+    setArgs.push_back(biasTeeArg);
+
     SoapySDR_logf(SOAPY_SDR_DEBUG, "SETARGS?");
 
     return setArgs;
@@ -576,6 +587,12 @@ void SoapyRTLSDR::writeSetting(const std::string &key, const std::string &value)
         SoapySDR_logf(SOAPY_SDR_DEBUG, "RTL-SDR digital agc mode: %s", digitalAGC ? "true" : "false");
         rtlsdr_set_agc_mode(dev, digitalAGC ? 1 : 0);
     }
+    else if (key == "bias_tee")
+    {
+        biasTee = (value == "true") ? true: false;
+        SoapySDR_logf(SOAPY_SDR_DEBUG, "RTL-SDR bias tee mode: %s", biasTee ? "true" : "false");
+        rtlsdr_set_bias_tee(dev, biasTee ? 1 : 0);
+    }
 }
 
 std::string SoapyRTLSDR::readSetting(const std::string &key) const
@@ -588,6 +605,8 @@ std::string SoapyRTLSDR::readSetting(const std::string &key) const
         return offsetMode?"true":"false";
     } else if (key == "digital_agc") {
         return digitalAGC?"true":"false";
+    } else if (key == "bias_tee") {
+        return biasTee?"true":"false";
     }
 
     SoapySDR_logf(SOAPY_SDR_WARNING, "Unknown setting '%s'", key.c_str());

--- a/SoapyRTLSDR.hpp
+++ b/SoapyRTLSDR.hpp
@@ -243,7 +243,7 @@ private:
     uint32_t sampleRate, centerFrequency;
     int ppm, directSamplingMode;
     size_t numBuffers, bufferLength, asyncBuffs;
-    bool iqSwap, gainMode, offsetMode, digitalAGC;
+    bool iqSwap, gainMode, offsetMode, digitalAGC, biasTee;
     double IFGain[6], tunerGain;
     std::atomic<long long> ticks;
 


### PR DESCRIPTION
This PR adds a setting that allows controlling the RTLSDR blog v3 bias-tee voltage.

See also: https://github.com/pothosware/SoapyRTLSDR/issues/30