### PR TITLE
Allow setting of direct_samp via init args

### DIFF
--- a/Settings.cpp
+++ b/Settings.cpp
@@ -79,6 +79,12 @@ SoapyRTLSDR::SoapyRTLSDR(const SoapySDR::Kwargs &args):
         gainMin = *std::min_element(gains.begin(), gains.end()) / 10.0;
         gainMax = *std::max_element(gains.begin(), gains.end()) / 10.0;
     }
+
+    // If requested, set initial direct sampling mode
+    if (args.count("direct_samp") != 0)
+    {
+        writeSetting("direct_samp", args.at("direct_samp"));
+    }
 }
 
 SoapyRTLSDR::~SoapyRTLSDR(void)


### PR DESCRIPTION
Direct sampling mode can currently only be set via `writeSetting()`. This adds the option of setting it upon initialisation.

In turn, this allows a user to trigger the mode from a client such as GQRX which has no specific support for writing settings but does allow a free-form device argument string.