### PR TITLE
Set lower tuning limit to 0MHz for RTL-SDR Blog V4

### DIFF
--- a/Settings.cpp
+++ b/Settings.cpp
@@ -398,8 +398,8 @@ SoapySDR::RangeList SoapyRTLSDR::getFrequencyRange(
         const std::string &name) const
 {
     SoapySDR::RangeList results;
-    char manufact[256];
-    char product[256];
+    char manufact[256] = {0};
+    char product[256] = {0};
 
     rtlsdr_get_usb_strings(dev, manufact, product, NULL);
 

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -398,6 +398,11 @@ SoapySDR::RangeList SoapyRTLSDR::getFrequencyRange(
         const std::string &name) const
 {
     SoapySDR::RangeList results;
+    char manufact[256];
+    char product[256];
+
+    rtlsdr_get_usb_strings(dev, manufact, product, NULL);
+
     if (name == "RF")
     {
         if (tunerType == RTLSDR_TUNER_E4000) {
@@ -406,6 +411,8 @@ SoapySDR::RangeList SoapyRTLSDR::getFrequencyRange(
             results.push_back(SoapySDR::Range(22000000, 1100000000));
         } else if (tunerType == RTLSDR_TUNER_FC0013) {
             results.push_back(SoapySDR::Range(22000000, 948600000));
+        } else if (tunerType == RTLSDR_TUNER_R828D && strcmp(manufact, "RTLSDRBlog") == 0 && strcmp(product, "Blog V4") == 0) {
+            results.push_back(SoapySDR::Range(0, 1764000000));
         } else {
             results.push_back(SoapySDR::Range(24000000, 1764000000));
         }

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -401,6 +401,7 @@ SoapySDR::RangeList SoapyRTLSDR::getFrequencyRange(
     char manufact[256] = {0};
     char product[256] = {0};
 
+    // Get manufact and product USB strings to detect RTL-SDR Blog V4 model
     rtlsdr_get_usb_strings(dev, manufact, product, NULL);
 
     if (name == "RF")
@@ -411,6 +412,7 @@ SoapySDR::RangeList SoapyRTLSDR::getFrequencyRange(
             results.push_back(SoapySDR::Range(22000000, 1100000000));
         } else if (tunerType == RTLSDR_TUNER_FC0013) {
             results.push_back(SoapySDR::Range(22000000, 948600000));
+        // The RTL-SDR Blog V4 can tune down to 0 MHz (in reality ~300 kHz) because of the built in upconverter.
         } else if (tunerType == RTLSDR_TUNER_R828D && strcmp(manufact, "RTLSDRBlog") == 0 && strcmp(product, "Blog V4") == 0) {
             results.push_back(SoapySDR::Range(0, 1764000000));
         } else {


### PR DESCRIPTION
The RTL-SDR Blog V4 can tune down to 0 MHz (in reality ~300 kHz) because of the built in upconverter. This change detects the Blog V4 via its R828D tuner, and the manufact and product strings, and sets the lower limit to 0 MHz.