### PR TITLE
Add Include <cstring> to resolve 'strcmp' undeclared issue

### DIFF
--- a/Settings.cpp
+++ b/Settings.cpp
@@ -26,6 +26,7 @@
 #include "SoapyRTLSDR.hpp"
 #include <SoapySDR/Time.hpp>
 #include <algorithm>
+#include <cstring>
 
 SoapyRTLSDR::SoapyRTLSDR(const SoapySDR::Kwargs &args):
     deviceId(-1),


### PR DESCRIPTION
Fix ‘strcmp’ was not declared in this scope
add `#include <cstring>` to fix compilation in gcc/clang.
https://github.com/pothosware/SoapyRTLSDR/blob/148c1eec9ec0e12de74625a7218bb8e812cc6d4d/Settings.cpp#L416