### PR TITLE
Fix uninitialized tunerGain in SoapyRTLSDR constructor

### DIFF
--- a/Settings.cpp
+++ b/Settings.cpp
@@ -51,6 +51,7 @@ SoapyRTLSDR::SoapyRTLSDR(const SoapySDR::Kwargs &args):
 #if HAS_RTLSDR_SET_DITHERING
     dithering(true),
 #endif
+    tunerGain(0.0),
     ticks(false),
     bufferedElems(0),
     resetBuffer(false),


### PR DESCRIPTION
This pull request addresses an issue within Gqrx where the tunerGain variable in the SoapyRTLSDR constructor remains uninitialized. As a result, when switching between different SoapySDR drivers, the tunerGain can assume abnormally large values, causing the Gqrx interface to become excessively wide and disrupting the user experience.
